### PR TITLE
xerrors / fix error output building

### DIFF
--- a/xerrors/error.go
+++ b/xerrors/error.go
@@ -16,18 +16,24 @@ func (m *messageError) Error() string {
 }
 
 func New(err error, message string) error {
-	var offset int
-	sep := ": "
-	if len(message) != 0 {
-		offset = len([]rune(sep))
-	}
+	var output []byte
 
 	errStr := err.Error()
-	output := make([]byte, len(errStr)+len(message)+offset)
 
-	copy(output, message)
-	copy(output[len(message):len(message)+offset], sep)
-	copy(output[len(message)+offset:], errStr)
+	if len(message) != 0 {
+		sep := ": "
+		offset := len([]rune(sep))
+
+		output = make([]byte, len(errStr)+len(message)+offset)
+		copy(output[len(message):len(message)+offset], sep)
+		copy(output[len(message)+offset:], errStr)
+		copy(output, message)
+	} else {
+
+		output = make([]byte, len(errStr))
+		copy(output[len(message):], errStr)
+		copy(output, message)
+	}
 
 	return &messageError{
 		err:     err,

--- a/xerrors/error.go
+++ b/xerrors/error.go
@@ -16,12 +16,18 @@ func (m *messageError) Error() string {
 }
 
 func New(err error, message string) error {
+	var offset int
+	sep := ": "
+	if len(message) != 0 {
+		offset = len([]rune(sep))
+	}
+
 	errStr := err.Error()
-	output := make([]byte, len(errStr)+len(message)+2)
+	output := make([]byte, len(errStr)+len(message)+offset)
 
 	copy(output, message)
-	copy(output[len(message):len(message)+2], ": ")
-	copy(output[len(message)+2:], errStr)
+	copy(output[len(message):len(message)+offset], sep)
+	copy(output[len(message)+offset:], errStr)
 
 	return &messageError{
 		err:     err,


### PR DESCRIPTION
**Описание:**
Если использовать цепочку методов типа: `Err(errors.New("test_error")).Send() `
То в выводе логов мы увидим сообщение: `: test_error`
**Причина:**
Некорректно обрабатывется случай, когда в аргумент `message` метода `func New(err error, message string) error ` попадает пустая строка.
**Cтало:**
1. Если использовать цепочку методов: `Err(errors.New("test_error")).Send() `
То в выводе логов мы увидим сообщение: `test_error`
2. Если использовать цепочку методов: `Err(errors.New("test_error")).Msg("foo")`
To в выводе логов мы увидим сообщение `foo: test_error`
3. Если использовать цепочку методов: `Err(errors.New("test_error")).MsgProto(codes.Unknown, "")`
To в выводе логов мы увидим сообщение `rpc error: code = Unknown desc = test_error` вместо `rpc error: code = Unknown desc = : test_error`