### PR TITLE
xerrors / add Proto method without message

### DIFF
--- a/xerrors/builder.go
+++ b/xerrors/builder.go
@@ -24,6 +24,7 @@ type ErrBuilder interface {
 	Send() error
 	Msg(msg string) error
 	MsgProto(code codes.Code, msg string) error
+	Proto(code codes.Code) error
 
 	Fielder
 }
@@ -75,6 +76,12 @@ func (e *errorBuilder) Msg(msg string) error {
 func (e *errorBuilder) MsgProto(code codes.Code, msg string) error {
 	defer e.resetSelf()
 	return status.Error(code, e.renderErr(msg).Error())
+}
+
+// Proto *status.Status proto error without message
+func (e *errorBuilder) Proto(code codes.Code) error {
+	defer e.resetSelf()
+	return status.Error(code, e.renderErr("").Error())
 }
 
 func Err(err error) ErrBuilder {


### PR DESCRIPTION
Было:
 Чтобы сбилдить ошибку для grpc и при этом не было необходимости прописывать дополнительное сообщение приходилось писать следующую цепочку методов: `Err(errors.New("test_error")).MsgProto(codes.Aborted, "")`
 
 Стало:
 Чтобы сбилдить ошибку для grpc без дополнительного сообщения достаточно написать `Err(errors.New("test_error")).Proto(codes.Aborted)`